### PR TITLE
Provide relative-scrolling and middle-start options; fixes

### DIFF
--- a/Scroll_Everywhere/scrolle.user.js
+++ b/Scroll_Everywhere/scrolle.user.js
@@ -21,7 +21,7 @@
 
 var mouseBtn, reverse, stopOnSecondClick, verticalScroll, startAnimDelay, cursorStyle, down,
     scrollevents, scrollBarWidth, cursorMask, isWin, fScrollX, fScrollY, fScroll, slowScrollStart,
-    lastX, lastY, scaleX, scaleY;
+    lastX, lastY, scaleX, scaleY, power;
 
 // NOTE: Do not run on iframes
 if (window.top === window.self) {
@@ -36,6 +36,7 @@ if (window.top === window.self) {
     relativeScrolling = false; // scroll the page relative to where we are now
     scaleX = -3; // how fast to scroll with relative scrolling
     scaleY = -3; // use negative values for "natural scrolling" (push the page)
+    power = 3; // when moving the mouse faster, how quickly should it speed up?
     // END
 
     fScroll = ((reverse) ? fRevPos : fPos);
@@ -90,7 +91,9 @@ function scroll(e) {
     if (relativeScrolling) {
       var diffX = e.clientX - lastX;
       var diffY = e.clientY - lastY;
-      window.scrollTo(window.scrollX + diffX * scaleX, window.scrollY + diffY * scaleY);
+      var distance = Math.sqrt(diffX * diffX + diffY * diffY);
+      var velocity = 1 + distance * power / 100;
+      window.scrollTo(window.scrollX + diffX * scaleX * velocity, window.scrollY + diffY * scaleY * velocity);
       lastX = e.clientX;
       lastY = e.clientY;
       return;

--- a/Scroll_Everywhere/scrolle.user.js
+++ b/Scroll_Everywhere/scrolle.user.js
@@ -22,7 +22,7 @@
 var mouseBtn, reverse, stopOnSecondClick, verticalScroll, startAnimDelay, cursorStyle, down,
     scrollevents, scrollBarWidth, cursorMask, isWin, fScrollX, fScrollY, fScroll, slowScrollStart;
 
-var middleIsStart, startX, startY, startScrollTop, startScrollLeft;
+var middleIsStart, startX, startY, startScrollTop, startScrollLeft, lastScrollHeight;
 
 var relativeScrolling, lastX, lastY, scaleX, scaleY, power, offsetMiddle;
 
@@ -64,10 +64,7 @@ function rightMbDown(e) {
     if (e.which == mouseBtn) {
         if (!down) {
             down = true;
-            startX = e.clientX;
-            startY = e.clientY;
-            startScrollTop = document.documentElement.scrollTop;
-            startScrollLeft = document.documentElement.scrollLeft;
+            setStartData(e);
             lastX = e.clientX;
             lastY = e.clientY;
             if (!slowScrollStart)
@@ -79,6 +76,14 @@ function rightMbDown(e) {
             stop();
         }
     }
+}
+
+function setStartData(e) {
+    lastScrollHeight = document.body.scrollHeight;
+    startX = e.clientX;
+    startY = e.clientY;
+    startScrollTop = document.documentElement.scrollTop;
+    startScrollLeft = document.documentElement.scrollLeft;
 }
 
 function waitScroll(e) {
@@ -93,6 +98,11 @@ function waitScroll(e) {
 }
 
 function scroll(e) {
+    // If the site has just changed the height of the webpage (e.g. by auto-loading more content)
+    // then we must adapt to the new height to avoid jumping.
+    if (lastScrollHeight !== document.body.scrollHeight) {
+        setStartData(e);
+    }
     //scrollevents += 1;
     if (!stopOnSecondClick && e.buttons === 0) {
         stop();

--- a/Scroll_Everywhere/scrolle.user.js
+++ b/Scroll_Everywhere/scrolle.user.js
@@ -9,7 +9,7 @@
 // @icon            https://raw.githubusercontent.com/tumpio/gmscripts/master/Scroll_Everywhere/large.png
 // @include         *
 // @grant           none
-// @version         0.3b
+// @version         0.3c
 // ==/UserScript==
 
 /* jshint multistr: true, strict: false, browser: true, devel: true */
@@ -20,8 +20,11 @@
 // FUTURE: Options dialog
 
 var mouseBtn, reverse, stopOnSecondClick, verticalScroll, startAnimDelay, cursorStyle, down,
-    scrollevents, scrollBarWidth, cursorMask, isWin, fScrollX, fScrollY, fScroll, slowScrollStart,
-    lastX, lastY, scaleX, scaleY, power;
+    scrollevents, scrollBarWidth, cursorMask, isWin, fScrollX, fScrollY, fScroll, slowScrollStart;
+
+var middleIsStart, startX, startY, startScrollTop, startScrollLeft;
+
+var relativeScrolling, lastX, lastY, scaleX, scaleY, power, offsetMiddle;
 
 // NOTE: Do not run on iframes
 if (window.top === window.self) {
@@ -33,6 +36,7 @@ if (window.top === window.self) {
     slowScrollStart = false; // slow scroll start on begin
     startAnimDelay = 150; // slow scroll start mode animation delay
     cursorStyle = "grab"; // cursor style on scroll
+    middleIsStart = false; // don't jump when the mouse starts moving
     relativeScrolling = false; // scroll the page relative to where we are now
     scaleX = 3; // how fast to scroll with relative scrolling
     scaleY = 3;
@@ -60,6 +64,10 @@ function rightMbDown(e) {
     if (e.which == mouseBtn) {
         if (!down) {
             down = true;
+            startX = e.clientX;
+            startY = e.clientY;
+            startScrollTop = document.documentElement.scrollTop;
+            startScrollLeft = document.documentElement.scrollLeft;
             lastX = e.clientX;
             lastY = e.clientY;
             window.addEventListener("mousemove", waitScroll, false);
@@ -128,10 +136,24 @@ function noScrollX() {
 }
 
 function fPos(win, doc, pos) {
+    if (middleIsStart) {
+        if (pos < startY) {
+            return startScrollTop * pos / startY;
+        } else {
+            return startScrollTop + (doc - startScrollTop) * (pos - startY) / (win - startY);
+        }
+    }
     return doc * (pos / win);
 }
 
 function fRevPos(win, doc, pos) {
+    if (middleIsStart) {
+        if (pos < startY) {
+            return startScrollTop + (doc - startScrollTop) * (startY - pos) / startY;
+        } else {
+            return startScrollTop - startScrollTop * (pos - startY) / (win - startY);
+        }
+    }
     return doc - fPos(win, doc, pos);
 }
 

--- a/Scroll_Everywhere/scrolle.user.js
+++ b/Scroll_Everywhere/scrolle.user.js
@@ -79,7 +79,7 @@ function rightMbDown(e) {
 }
 
 function setStartData(e) {
-    lastScrollHeight = document.body.scrollHeight;
+    lastScrollHeight = getScrollHeight();
     startX = e.clientX;
     startY = e.clientY;
     // On some pages, body.scrollTop changes whilst documentElement.scrollTop remains 0.
@@ -103,7 +103,7 @@ function waitScroll(e) {
 function scroll(e) {
     // If the site has just changed the height of the webpage (e.g. by auto-loading more content)
     // then we must adapt to the new height to avoid jumping.
-    if (lastScrollHeight !== document.body.scrollHeight) {
+    if (lastScrollHeight !== getScrollHeight()) {
         setStartData(e);
     }
     //scrollevents += 1;
@@ -126,11 +126,11 @@ function scroll(e) {
     window.scrollTo(
         fScrollX(
             window.innerWidth - scrollBarWidth,
-            document.body.scrollWidth - window.innerWidth,
+            getScrollWidth() - window.innerWidth,
             e.clientX),
         fScrollY(
             window.innerHeight - scrollBarWidth,
-            document.body.scrollHeight - window.innerHeight,
+            getScrollHeight() - window.innerHeight,
             e.clientY)
     );
 }
@@ -170,6 +170,14 @@ function fRevPos(win, doc, pos) {
         }
     }
     return doc - fPos(win, doc, pos);
+}
+
+function getScrollHeight(e) {
+  return document.body.scrollHeight || document.documentElement.scrollHeight || 0;
+}
+
+function getScrollWidth(e) {
+  return document.body.scrollWidth || document.documentElement.scrollWidth || 0;
 }
 
 function getScrollBarWidth() {

--- a/Scroll_Everywhere/scrolle.user.js
+++ b/Scroll_Everywhere/scrolle.user.js
@@ -9,7 +9,7 @@
 // @icon            https://raw.githubusercontent.com/tumpio/gmscripts/master/Scroll_Everywhere/large.png
 // @include         *
 // @grant           none
-// @version         0.3a
+// @version         0.3b
 // ==/UserScript==
 
 /* jshint multistr: true, strict: false, browser: true, devel: true */
@@ -20,7 +20,8 @@
 // FUTURE: Options dialog
 
 var mouseBtn, reverse, stopOnSecondClick, verticalScroll, startAnimDelay, cursorStyle, down,
-    scrollevents, scrollBarWidth, cursorMask, isWin, fScrollX, fScrollY, fScroll, slowScrollStart;
+    scrollevents, scrollBarWidth, cursorMask, isWin, fScrollX, fScrollY, fScroll, slowScrollStart,
+    lastX, lastY, scaleX, scaleY;
 
 // NOTE: Do not run on iframes
 if (window.top === window.self) {
@@ -32,6 +33,9 @@ if (window.top === window.self) {
     slowScrollStart = false; // slow scroll start on begin
     startAnimDelay = 150; // slow scroll start mode animation delay
     cursorStyle = "grab"; // cursor style on scroll
+    relativeScrolling = false; // scroll the page relative to where we are now
+    scaleX = -3; // how fast to scroll with relative scrolling
+    scaleY = -3; // use negative values for "natural scrolling" (push the page)
     // END
 
     fScroll = ((reverse) ? fRevPos : fPos);
@@ -55,6 +59,8 @@ function rightMbDown(e) {
     if (e.which == mouseBtn) {
         if (!down) {
             down = true;
+            lastX = e.clientX;
+            lastY = e.clientY;
             window.addEventListener("mousemove", waitScroll, false);
             if (!stopOnSecondClick)
                 window.addEventListener("mouseup", stop, false);
@@ -81,6 +87,15 @@ function scroll(e) {
         stop();
         return;
     }
+    if (relativeScrolling) {
+      var diffX = e.clientX - lastX;
+      var diffY = e.clientY - lastY;
+      window.scrollTo(window.scrollX + diffX * scaleX, window.scrollY + diffY * scaleY);
+      lastX = e.clientX;
+      lastY = e.clientY;
+      return;
+    }
+    // The original absolute scrolling
     window.scrollTo(
         fScrollX(
             window.innerWidth - scrollBarWidth,

--- a/Scroll_Everywhere/scrolle.user.js
+++ b/Scroll_Everywhere/scrolle.user.js
@@ -70,6 +70,8 @@ function rightMbDown(e) {
             startScrollLeft = document.documentElement.scrollLeft;
             lastX = e.clientX;
             lastY = e.clientY;
+            if (!slowScrollStart)
+              scroll(e);
             window.addEventListener("mousemove", waitScroll, false);
             if (!stopOnSecondClick)
                 window.addEventListener("mouseup", stop, false);

--- a/Scroll_Everywhere/scrolle.user.js
+++ b/Scroll_Everywhere/scrolle.user.js
@@ -34,8 +34,8 @@ if (window.top === window.self) {
     startAnimDelay = 150; // slow scroll start mode animation delay
     cursorStyle = "grab"; // cursor style on scroll
     relativeScrolling = false; // scroll the page relative to where we are now
-    scaleX = -3; // how fast to scroll with relative scrolling
-    scaleY = -3; // use negative values for "natural scrolling" (push the page)
+    scaleX = 3; // how fast to scroll with relative scrolling
+    scaleY = 3;
     power = 3; // when moving the mouse faster, how quickly should it speed up?
     // END
 
@@ -93,7 +93,8 @@ function scroll(e) {
       var diffY = e.clientY - lastY;
       var distance = Math.sqrt(diffX * diffX + diffY * diffY);
       var velocity = 1 + distance * power / 100;
-      window.scrollTo(window.scrollX + diffX * scaleX * velocity, window.scrollY + diffY * scaleY * velocity);
+      var reverseScale = reverse ? -1 : 1;
+      window.scrollTo(window.scrollX + diffX * scaleX * velocity * reverseScale, window.scrollY + diffY * scaleY * velocity * reverseScale);
       lastX = e.clientX;
       lastY = e.clientY;
       return;

--- a/Scroll_Everywhere/scrolle.user.js
+++ b/Scroll_Everywhere/scrolle.user.js
@@ -82,8 +82,11 @@ function setStartData(e) {
     lastScrollHeight = document.body.scrollHeight;
     startX = e.clientX;
     startY = e.clientY;
-    startScrollTop = document.documentElement.scrollTop;
-    startScrollLeft = document.documentElement.scrollLeft;
+    // On some pages, body.scrollTop changes whilst documentElement.scrollTop remains 0.
+    // For example: https://docs.kde.org/trunk5/en/kde-workspace/kcontrol/autostart/index.html
+    // See: https://stackoverflow.com/questions/19618545
+    startScrollTop = document.documentElement.scrollTop || document.body.scrollTop || 0;
+    startScrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft || 0;
 }
 
 function waitScroll(e) {


### PR DESCRIPTION
Motivation: When I start to drag, the page suddenly jumps to a new position. This can cause me to lose my place, especially if I just wanted to scroll down a small amount (e.g. one page). So I would like the dragging to start from the current page position.

Without changing the default behaviour of the script, this PR adds two different ways of doing that.

----

With `middleStart = true` the mouse coordinates where dragging started will match the page's scroll position when dragging started. This is done by scaling the drag regions above and below the start coordinates differently.

This keeps the ability to scroll the entire page in one drag, which is one of ScrollEverywhere's nice features.

----

Alternatively, if you set `relativeScrolling = true` then moving the mouse will scroll the page relative to its current scroll position, at a rate relative to the mouse movement speed.

With `reverse = true` this feels like scrolling on a mobile phone or a tablet, where you "push" the page with your fingers. (I have also added some velocity, so you can get faster scrolling from faster mouse movement.)

Unfortunately this method does not retain the ability to scroll the entire page in one drag, at least not so intuitively.

----

It occurs to me now that when using ScrollEverywhere with its default settings, the trick is to look at the scrollbar widget, and start your mouse-drag from the top/middle of the widget. That avoids the jumping affect from happening!

This hadn't occurred to me when I started using ScrollEverywhere. (I was expecting to scroll relative to the page's current position.) Perhaps the suggestion could be made clear in the documentation, to assist user onboarding.

----

The fixes for scrollTop, scrollWidth and scrollHeight help the script to work on more sites (e.g. YouTube). Not sure why we sometimes need to read the value from different places.