### PR TITLE
Fix bug in Firefox where overflow didn't reset

### DIFF
--- a/Scroll_Everywhere/scrolle.user.js
+++ b/Scroll_Everywhere/scrolle.user.js
@@ -9,7 +9,7 @@
 // @icon            https://raw.githubusercontent.com/tumpio/gmscripts/master/Scroll_Everywhere/large.png
 // @include         *
 // @grant           none
-// @version         0.3c
+// @version         0.3d
 // ==/UserScript==
 
 /* jshint multistr: true, strict: false, browser: true, devel: true */
@@ -181,13 +181,20 @@ function getScrollWidth(e) {
 }
 
 function getScrollBarWidth() {
-    var style = document.body.style.overflow;
+    var originalOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
     var width = document.body.clientWidth;
     document.body.style.overflow = 'scroll';
     width -= document.body.clientWidth;
     if (!width) width = document.body.offsetWidth - document.body.clientWidth;
-    document.body.style.overflow = style;
+
+    // Now we set overflow back to how it was
+    // But if style === '' then Firefox will sometimes leave the temporary scrollbar still showing!
+    // We can prevent that by setting it to 'initial', and forcing a relayout, before setting it to ''
+    document.body.style.overflow = originalOverflow || 'initial';
+    var triggerLayout = document.body.clientWidth;
+    document.body.style.overflow = originalOverflow;
+
     return width;
 }
 


### PR DESCRIPTION
I've been getting unwanted horizontal scrollbars for a few months now. Today I discovered the cause, and a solution.

I also renamed the variable, sorry!

(Setting `overflow` back to `''` hasn't been necessary in my experience, but it feels better to leave things how they were before.)

I just added this fix today. If you want to wait a week, I can report whether there were any issues.

To reproduce: I see the problem when logged in to https://messenger.com/ 

Currently using: Firefox Developer Edition 78.0b9 (64-bit)