### PR TITLE
Fix minor layout issue

### DIFF
--- a/Endless_Google/egoogle.user.js
+++ b/Endless_Google/egoogle.user.js
@@ -10,7 +10,7 @@
 // @include         https://www.google.*
 // @include         https://encrypted.google.*
 // @run-at          document-start
-// @version         0.0.6
+// @version         0.0.7
 // @license         MIT
 // @noframes
 // ==/UserScript==
@@ -77,6 +77,8 @@ function requestNextPage() {
 
             content.id = "col_" + pageNumber;
             filter(content, filtersCol);
+
+            content.style.marginLeft = '0';
 
             let pageMarker = document.createElement("div");
             pageMarker.textContent = String(pageNumber + 1);


### PR DESCRIPTION
Currently on Google Search I am seeing the extra pages have an unwanted margin on the left-hand side, and appear greatly indented compared to the original page. (Basically they are getting the `180px` margin twice.)

This fixes it.